### PR TITLE
add docker format to buildah

### DIFF
--- a/etm-buildah/build-oci.sh
+++ b/etm-buildah/build-oci.sh
@@ -16,6 +16,6 @@ cp -f $SCRIPT_DIR/config/etm.yml $dir/opt/etm-$VERSION/config
 
 ## CONFIGURE ETM
 buildah config --port 8080 --entrypoint "[\"/opt/etm-$VERSION/bin/etm\", \"console\"]" $container
-buildah commit $container docker.jecstar.com/etm:$VERSION
+buildah commit --format docker $container docker.jecstar.com/etm:$VERSION
 buildah tag docker.jecstar.com/etm:$VERSION eu.gcr.io/virtual-ellipse-208415/etm:$VERSION
 buildah unmount $container


### PR DESCRIPTION
Google Kubernetes give error when try to deploy ETM image build base on Buildah.

Failed to pull image "docker.jecstar.com/etm:4.2.0": rpc error: code = Unknown desc = Error response from daemon: mediaType in manifest should be 'application/vnd.docker.distribution.manifest.v2+json' not ''